### PR TITLE
Make GitHub token optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
 
 ### `github_token`
 
-**Required**. Default is `${{ github.token }}`.
+Optional. Default is `${{ github.token }}`.
 
 ### `clippy_flags`
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   github_token:
     description: "GITHUB_TOKEN."
-    required: true
+    required: false
     default: ${{ github.token }}
   clippy_flags:
     description: "clippy flags. (cargo clippy --color never -q --message-format json `<clippy_flags>`)"


### PR DESCRIPTION
As we use `${{github.token}}` as default, this should be optional.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>