### PR TITLE
Bump Node runtime version to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,5 +50,5 @@ inputs:
     required: false
     default: latest
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
[GitHub intends for every GitHub Action to migrate to Node 20 by Spring 2024](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), and we are on Spring 2024. To move forward and do not cause inconveniences to users (due to the deprecation warning that this action shows when used on workflows) and GitHub (so that they don't have reasons to delay the upgrade), let's update this action to use Node 20.

As far as I can see, this action does not need any code changes to work under a Node 20 runtime.

Fixes #86.